### PR TITLE
fix: add missing caller permissions

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,3 +10,6 @@ on:
 jobs:
     prerelease:
         uses: apermo/reusable-workflows/.github/workflows/reusable-prerelease.yml@main
+        permissions:
+            contents: write
+            pull-requests: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,3 +7,6 @@ on:
 jobs:
     stale:
         uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@main
+        permissions:
+            issues: write
+            pull-requests: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - Unreleased
+
+### Fixed
+
+- Workflow callers missing permissions (caused startup_failure)
+
 ## [0.2.1] - 2026-03-03
 
 ### Changed


### PR DESCRIPTION
## Summary

- Add `issues: write` and `pull-requests: write` to stale caller
- Add `contents: write` and `pull-requests: write` to prerelease caller

Without explicit permissions, these workflows fail with `startup_failure` on repos with restricted default token permissions.